### PR TITLE
Prevent login issues

### DIFF
--- a/back/taiga_contrib_oidc_auth/views.py
+++ b/back/taiga_contrib_oidc_auth/views.py
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from six.moves.urllib.parse import urlencode
+from django.utils.http import urlencode
 
 from mozilla_django_oidc.views import OIDCAuthenticationCallbackView
 from mozilla_django_oidc.utils import import_from_settings
@@ -28,8 +28,10 @@ def _make_login_url(data):
             "front": {"domain": "localhost:9001", "scheme": "http", "name": "front"},
         },
     )
+    filtered_dict = {k: v for k, v in data.items() if v is not None}
+
     return "{}://{}/login?{}".format(
-        SITES["front"]["scheme"], SITES["front"]["domain"], urlencode(data)
+        SITES["front"]["scheme"], SITES["front"]["domain"], urlencode(filtered_dict)
     )
 
 


### PR DESCRIPTION
* Prevent unexpected login error when the user already exists

This avoids errors with the user it's already registered using alternative methods to OIDC login.

* Login with user data not including empty fields

Fix some render issues on first user login due to some `None` strings that came from the redirect. 